### PR TITLE
Replacing the CONSTANT export by DATA, small fixes all around

### DIFF
--- a/MSVC12/algo_test/algo_test.vcxproj
+++ b/MSVC12/algo_test/algo_test.vcxproj
@@ -138,6 +138,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -173,6 +174,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/MSVC12/openfstwin.props
+++ b/MSVC12/openfstwin.props
@@ -12,7 +12,7 @@
       <PreprocessorDefinitions>WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;$(SolutionDir)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ProjectReference>

--- a/MSVC12/openfstwinlib/openfst.def
+++ b/MSVC12/openfstwinlib/openfst.def
@@ -1,17 +1,20 @@
 LIBRARY
 EXPORTS
-	PropertyNames CONSTANT
-	FLAGS_fst_verify_properties CONSTANT
-	FLAGS_fst_weight_separator CONSTANT
-	FLAGS_fst_weight_parentheses CONSTANT		
-	FLAGS_fst_default_cache_gc_limit CONSTANT
-	FLAGS_save_relabel_ipairs CONSTANT
-	FLAGS_save_relabel_opairs	CONSTANT
-	FLAGS_v CONSTANT
-	FLAGS_help CONSTANT
-	FLAGS_tmpdir CONSTANT
-	FLAGS_fst_compat_symbols CONSTANT
-	FLAGS_fst_field_separator CONSTANT
-	FLAGS_fst_default_cache_gc CONSTANT
-	FLAGS_fst_align CONSTANT
-  FLAGS_fst_error_fatal CONSTANT
+    PropertyNames DATA
+    FLAGS_far_field_separator DATA
+    FLAGS_save_relabel_ipairs DATA
+    FLAGS_save_relabel_opairs DATA
+    FLAGS_fst_verify_properties DATA
+    FLAGS_fst_weight_separator DATA
+    FLAGS_fst_weight_parentheses DATA
+    FLAGS_fst_default_cache_gc_limit DATA
+    FLAGS_save_relabel_ipairs DATA
+    FLAGS_save_relabel_opairs	DATA
+    FLAGS_v DATA
+    FLAGS_help DATA
+    FLAGS_tmpdir DATA
+    FLAGS_fst_compat_symbols DATA
+    FLAGS_fst_field_separator DATA
+    FLAGS_fst_default_cache_gc DATA
+    FLAGS_fst_align DATA
+    FLAGS_fst_error_fatal DATA

--- a/src/include/fst/cache.h
+++ b/src/include/fst/cache.h
@@ -29,8 +29,8 @@ using std::vector;
 #include <fst/vector-fst.h>
 
 
-DECLARE_bool(fst_default_cache_gc);
-DECLARE_int64(fst_default_cache_gc_limit);
+DECLARE_CORE_bool(fst_default_cache_gc);
+DECLARE_CORE_int64(fst_default_cache_gc_limit);
 
 namespace fst {
 

--- a/src/include/fst/extensions/far/print-strings.h
+++ b/src/include/fst/extensions/far/print-strings.h
@@ -30,7 +30,7 @@ using std::vector;
 #include <fst/shortest-distance.h>
 #include <fst/string.h>
 
-DECLARE_string(far_field_separator);
+DECLARE_CORE_string(far_field_separator);
 
 namespace fst {
 

--- a/src/include/fst/flags.h
+++ b/src/include/fst/flags.h
@@ -30,7 +30,7 @@
 #include <fst/lock.h>
 
 using std::string;
-#ifdef _MSC_VER 
+#ifdef _MSC_VER
 	#define strtoll _strtoi64
 	#define atoll atol
 	//#ifndef I_AM_A_DLL
@@ -41,12 +41,12 @@ using std::string;
 	//#define IMPORT __declspec(dllexport)
 	//#endif
 	#ifdef OPENFSTEXPORT
-		#define  OPENFSTDLL  __declspec(dllexport) 
+		#define  OPENFSTDLL  __declspec(dllexport)
 	#else
 		#define  OPENFSTDLL __declspec(dllimport)
 	#endif
 #else
-		#define OPENFSTDLL  
+		#define OPENFSTDLL
 #endif
 //
 // FLAGS USAGE:
@@ -67,11 +67,19 @@ using std::string;
 // ShowUsage() can be used to print out command and flag usage.
 //
 
-#define DECLARE_bool(name) OPENFSTDLL extern bool FLAGS_ ## name
-#define DECLARE_string(name) OPENFSTDLL extern string FLAGS_ ## name
-#define DECLARE_int32(name) OPENFSTDLL extern int32 FLAGS_ ## name
-#define DECLARE_int64(name) OPENFSTDLL extern int64 FLAGS_ ## name
-#define DECLARE_double(name) OPENFSTDLL extern double FLAGS_ ## name
+#define DECLARE_CORE_bool(name) OPENFSTDLL extern bool FLAGS_ ## name
+#define DECLARE_CORE_string(name) OPENFSTDLL extern string FLAGS_ ## name
+#define DECLARE_CORE_int32(name) OPENFSTDLL extern int32 FLAGS_ ## name
+#define DECLARE_CORE_int64(name) OPENFSTDLL extern int64 FLAGS_ ## name
+#define DECLARE_CORE_double(name) OPENFSTDLL extern double FLAGS_ ## name
+
+#ifndef OPENFSTEXPORT
+#define DECLARE_bool(name)  extern bool FLAGS_ ## name
+#define DECLARE_string(name)  extern string FLAGS_ ## name
+#define DECLARE_int32(name)  extern int32 FLAGS_ ## name
+#define DECLARE_int64(name)  extern int64 FLAGS_ ## name
+#define DECLARE_double(name)  extern double FLAGS_ ## name
+#endif
 
 template <typename T>
 struct FlagDescription {
@@ -223,7 +231,17 @@ class FlagRegisterer {
   DISALLOW_COPY_AND_ASSIGN(FlagRegisterer);
 };
 
+#ifdef OPENFSTEXPORT
+#define DEFINE_VAR(type, name, value, doc)                                \
+  __declspec(dllexport) type FLAGS_ ## name = value;                      \
+  static FlagRegisterer<type>                                             \
+  name ## _flags_registerer(#name, FlagDescription<type>(&FLAGS_ ## name, \
+                                                         doc,             \
+                                                         #type,           \
+                                                         __FILE__,        \
+                                                         value))
 
+#else
 #define DEFINE_VAR(type, name, value, doc)                                \
   type FLAGS_ ## name = value;                                            \
   static FlagRegisterer<type>                                             \
@@ -232,6 +250,7 @@ class FlagRegisterer {
                                                          #type,           \
                                                          __FILE__,        \
                                                          value))
+#endif
 
 #define DEFINE_bool(name, value, doc) DEFINE_VAR(bool, name, value, doc)
 #define DEFINE_string(name, value, doc) \
@@ -242,10 +261,10 @@ class FlagRegisterer {
 
 
 // Temporary directory
-DECLARE_string(tmpdir);
+DECLARE_CORE_string(tmpdir);
 
 void OPENFSTDLL SetFlags(const char *usage, int *argc, char ***argv, bool remove_flags, //ChangedPD
-              const char *src = ""); 
+              const char *src = "");
 
 #define SET_FLAGS(usage, argc, argv, rmflags) \
 SetFlags(usage, argc, argv, rmflags, __FILE__)

--- a/src/include/fst/fst.h
+++ b/src/include/fst/fst.h
@@ -41,7 +41,7 @@
 #include <fst/util.h>
 
 
-DECLARE_bool(fst_align);
+DECLARE_CORE_bool(fst_align);
 
 namespace fst {
 

--- a/src/include/fst/log.h
+++ b/src/include/fst/log.h
@@ -29,7 +29,7 @@
 
 using std::string;
 
-DECLARE_int32(v);
+DECLARE_CORE_int32(v);
 
 class LogMessage {
  public:

--- a/src/include/fst/lookahead-matcher.h
+++ b/src/include/fst/lookahead-matcher.h
@@ -29,8 +29,8 @@
 #include <fst/matcher.h>
 
 
-DECLARE_string(save_relabel_ipairs);
-DECLARE_string(save_relabel_opairs);
+DECLARE_CORE_string(save_relabel_ipairs);
+DECLARE_CORE_string(save_relabel_opairs);
 
 namespace fst {
 

--- a/src/include/fst/mapped-file.h
+++ b/src/include/fst/mapped-file.h
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <sstream>
 
-DECLARE_int32(fst_arch_alignment);  // defined in mapped-file.h
+DECLARE_CORE_int32(fst_arch_alignment);  // defined in mapped-file.h
 
 namespace fst {
 

--- a/src/include/fst/pair-weight.h
+++ b/src/include/fst/pair-weight.h
@@ -29,8 +29,8 @@
 #include <fst/weight.h>
 
 
-DECLARE_string(fst_weight_parentheses);
-DECLARE_string(fst_weight_separator);
+DECLARE_CORE_string(fst_weight_parentheses);
+DECLARE_CORE_string(fst_weight_separator);
 
 namespace fst {
 

--- a/src/include/fst/properties.h
+++ b/src/include/fst/properties.h
@@ -453,7 +453,7 @@ uint64 AddArcProperties(uint64 inprops, typename A::StateId s,
   return outprops;
 }
 
-extern const char *PropertyNames[];
+OPENFSTDLL extern const char *PropertyNames[];
 
 }  // namespace fst
 

--- a/src/include/fst/script/compile-impl.h
+++ b/src/include/fst/script/compile-impl.h
@@ -36,7 +36,7 @@ using std::vector;
 #include <fst/util.h>
 #include <fst/vector-fst.h>
 
-DECLARE_string(fst_field_separator);
+DECLARE_CORE_string(fst_field_separator);
 
 namespace fst {
 

--- a/src/include/fst/script/print-impl.h
+++ b/src/include/fst/script/print-impl.h
@@ -28,7 +28,7 @@
 #include <fst/fst.h>
 #include <fst/util.h>
 
-DECLARE_string(fst_field_separator);
+DECLARE_CORE_string(fst_field_separator);
 
 namespace fst {
 

--- a/src/include/fst/sparse-tuple-weight.h
+++ b/src/include/fst/sparse-tuple-weight.h
@@ -40,8 +40,8 @@ using std::tr1::unordered_multimap;
 #include <fst/weight.h>
 
 
-DECLARE_string(fst_weight_parentheses);
-DECLARE_string(fst_weight_separator);
+DECLARE_CORE_string(fst_weight_parentheses);
+DECLARE_CORE_string(fst_weight_separator);
 
 namespace fst {
 

--- a/src/include/fst/string.h
+++ b/src/include/fst/string.h
@@ -27,7 +27,7 @@
 #include <fst/icu.h>
 #include <fst/mutable-fst.h>
 
-DECLARE_string(fst_field_separator);
+DECLARE_CORE_string(fst_field_separator);
 
 namespace fst {
 

--- a/src/include/fst/symbol-table.h
+++ b/src/include/fst/symbol-table.h
@@ -38,7 +38,7 @@ using std::vector;
 
 #include <map>
 
-DECLARE_bool(fst_compat_symbols);
+DECLARE_CORE_bool(fst_compat_symbols);
 
 namespace fst {
 

--- a/src/include/fst/test-properties.h
+++ b/src/include/fst/test-properties.h
@@ -29,7 +29,7 @@ using std::tr1::unordered_multiset;
 #include <fst/connect.h>
 
 
-DECLARE_bool(fst_verify_properties);
+DECLARE_CORE_bool(fst_verify_properties);
 
 namespace fst {
 

--- a/src/include/fst/tuple-weight.h
+++ b/src/include/fst/tuple-weight.h
@@ -28,8 +28,8 @@ using std::vector;
 #include <fst/weight.h>
 
 
-DECLARE_string(fst_weight_parentheses);
-DECLARE_string(fst_weight_separator);
+DECLARE_CORE_string(fst_weight_parentheses);
+DECLARE_CORE_string(fst_weight_separator);
 
 namespace fst {
 

--- a/src/include/fst/util.h
+++ b/src/include/fst/util.h
@@ -47,7 +47,7 @@ using std::vector;
 // UTILITY FOR ERROR HANDLING
 //
 
-DECLARE_bool(fst_error_fatal);
+DECLARE_CORE_bool(fst_error_fatal);
 
 #define FSTERROR() (FLAGS_fst_error_fatal ? LOG(FATAL) : LOG(ERROR))
 

--- a/src/test/algo_test.h
+++ b/src/test/algo_test.h
@@ -25,6 +25,7 @@
 #include <fst/random-weight.h>
 
 DECLARE_int32(repeat);  // defined in ./algo_test.cc
+DECLARE_CORE_string(tmpdir);
 
 namespace fst {
 

--- a/src/test/fst_test.h
+++ b/src/test/fst_test.h
@@ -26,7 +26,7 @@
 #include <fst/vector-fst.h>
 #include <fst/verify.h>
 
-DECLARE_string(tmpdir);
+DECLARE_CORE_string(tmpdir);
 
 namespace fst {
 


### PR DESCRIPTION
I fixed some compilation issues under MSVC12 and finally managed to convert the CONSTANT exports to DATA, so now there is much less compilation warnings. +Some other small fixes
Signed-off-by: Yenda Trmal jtrmal@gmail.com
